### PR TITLE
Changes to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,8 @@ In your local RStudio, copy your API key in a command like this and run:
 ```{r, eval = FALSE}
 Sys.setenv(CONNECT_API_KEY = "your-api-key")
 ```
-You should only need to do this once per your RStudio environment. Your API key is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the API key functions below use by default, e.g.:
+
+It is stored in the environment for the current R session. You should only need to do this once per your RStudio environment. Your API key is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the API key functions below use by default, e.g.:
 
 ```{r, eval = FALSE}
 mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,18 +42,16 @@ Before you can run `mario`, you will need two things:
 You will need access to the mario RSConnect through your institution. For example, JHU users will login at https://rsconnect.biostat.jhsph.edu/connect/. Once there, you'll need to obtain an API token.
 Click on your profile in the upper right corner > `API Keys` > `+ New API Key` and copy that API key token.
 
-In your local RStudio copy your API key in a command like this and run:
+In your local RStudio, copy your API key in a command like this and run:
 
 ```{r, eval = FALSE}
 Sys.setenv(CONNECT_API_KEY = "your-api-key")
 ```
-You should only need to do this once per your RStudio environment. Your API key is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the api key functions below use by default, e.g.:
+You should only need to do this once per your RStudio environment. Your API key is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the API key functions below use by default, e.g.:
 
 ```{r, eval = FALSE}
 mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))
 ```
-
-
 
 Now to test if your API key has been set up correctly, run this:
 ```{r, eval = FALSE}
@@ -70,7 +68,7 @@ If set up correctly, it should repeat back to you your API key.
 If you have a Google Slides set, you can obtain the Google Slides set ID from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
-Your [Google Slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with the link`
+Your [Google Slides permissions](https://www.youtube.com/watch?v=zHSfwaZIVbM) must be set to `Anyone with the link`.
 For testing purposes, we've included a set of [test slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p) you can use to practice.
 
 ## Running Mario
@@ -88,8 +86,7 @@ mario::mario_write_video(
   res)
 ```
 
-Mario will print a file path to the newly rendered video in the console.
-If you'd like to see a list of all the voice options:
+Mario will print a file path to the newly rendered video in the console. If you'd like to see a list of all the voice options:
 
 ```{r, eval = FALSE}
 voice_options <- mario_voices()

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# mario
+# mario Package:
 
 The goal of `mario` is to create automatically create videos from a Google slides.
 Whatever is written in the speaker notes section of the Google slides will be read in the video.
@@ -67,7 +67,7 @@ If it is set up correctly, if should repeat back to you your API key.
 If you have a google slide set, you can obtain the google slide set ID from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
-Your [Google slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with link can view`
+Your [Google slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with the link`
 For testing purposes, we've included a set of [test slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p) you can use to practice.
 
 ## Running Mario

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,3 +93,23 @@ Mario will print a file path to the newly rendered video in the console. If you'
 voice_options <- mario_voices()
 head(voice_options)
 ```
+
+
+## Getting Mario subtitles for YouTube
+
+```{r, eval = FALSE}
+# Extract the subtitles
+subtitles <- mario::mario_subtitles(res)
+# Write the subtitles to file
+readr::write_lines(subtitles, "out.txt")
+```
+
+On YouTube:
+
+- Navigate to [https://studio.youtube.com](https://studio.youtube.com)
+- Go to "Subtitles" on the left hand menu
+- Click on the video to which you want to add subtitles
+- Click the "ADD" link under "Subtitles" in the table
+- Select Upload File and select "With timing"
+- Upload the "out.txt" file created above
+- Once checked, click "PUBLISH"

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ If you update the slides, all you need to do is re-run `mario` to update the vid
 
 You can install `mario` from GitHub with:
 
-``` r
+```{r, eval = FALSE}
 # install.packages("remotes")
 remotes::install_github("jhudsl/mario")
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,8 +16,9 @@ knitr::opts_chunk$set(
 
 # mario Package:
 
-The goal of `mario` is to create automatically create videos from a Google Slides
-Whatever is written in the speaker notes section of the Google Slides will be read in the video.
+The goal of `mario` is to automatically create videos from a set of
+Google Slides. Whatever is written in the speaker notes section of the
+Google Slides will be read in the video.
 
 If you update the slides, all you need to do is re-run `mario` to update the video.
 
@@ -34,10 +35,10 @@ remotes::install_github("jhudsl/mario")
 
 Before you can run `mario`, you will need two things:
 
-1) An API Key
-2) Google Slide ID that you'd like to translate into a video
+1) [API Key](#api-key)
+2) [Google Slides ID](#google-slides-id)
 
-### An API Key
+### API Key
 
 You will need access to the mario RSConnect through your institution. For example, JHU users will login at https://rsconnect.biostat.jhsph.edu/connect/. Once there, you'll need to obtain an API token.
 Click on your profile in the upper right corner > `API Keys` > `+ New API Key` and copy that API key token.
@@ -63,7 +64,7 @@ if (mario_have_api_key()) {
 ```
 If set up correctly, it should repeat back to you your API key.
 
-### Google Slide ID that you'd like to translate into a video
+### Google Slides ID
 
 If you have a Google Slides set, you can obtain the Google Slides set ID from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# mario Package:
+# mario
 
 The goal of `mario` is to create automatically create videos from a Google slides.
 Whatever is written in the speaker notes section of the Google slides will be read in the video.

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,9 @@ It is called `CONNECT_API_KEY`. You can call it something else, but this is the 
 
 
 Now to test if your API key has been set up correctly, run this:
-```
+```{r, eval = FALSE}
+library(mario)
+
 if (mario_have_api_key()) {
   mario_api_key()
 }
@@ -64,15 +66,15 @@ If it is set up correctly, if should repeat back to you your API key.
 
 ### Get your Google Slide ID
 
-If you have a google slide set, you can obtain the google slide set ID from the URL:
+If you have a Google Slides set, you can obtain the Google Slides set ID from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
-Your [Google slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with the link`
+Your [Google Slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with the link`
 For testing purposes, we've included a set of [test slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p) you can use to practice.
 
 ## Running Mario
 
-```{r}
+```{r, eval = FALSE}
 # Google slide ID
 id <- "1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk"
 
@@ -82,14 +84,13 @@ res <- mario::mario(id,
 
 # Write the video
 mario::mario_write_video(
-  res
-  file = file.path())
+  res)
 ```
 
 Mario will print a file path to the newly rendered video in the console.
 If you'd like to see a list of all the voice options:
 
-```{r}
+```{r, eval = FALSE}
 voice_options <- mario_voices()
 head(voice_options)
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,8 +16,8 @@ knitr::opts_chunk$set(
 
 # mario Package:
 
-The goal of `mario` is to create automatically create videos from a Google slides.
-Whatever is written in the speaker notes section of the Google slides will be read in the video.
+The goal of `mario` is to create automatically create videos from a Google Slides
+Whatever is written in the speaker notes section of the Google Slides will be read in the video.
 
 If you update the slides, all you need to do is re-run `mario` to update the video.
 
@@ -35,9 +35,9 @@ remotes::install_github("jhudsl/mario")
 Before you can run `mario`, you will need two things:
 
 1) An API Key
-2) Your Google slide ID that you'd like to translate into a video
+2) Google Slide ID that you'd like to translate into a video
 
-### Get and set the API Key
+### An API Key
 
 You will need access to the mario RSConnect through your institution. For example, JHU users will login at https://rsconnect.biostat.jhsph.edu/connect/. Once there, you'll need to obtain an API token.
 Click on your profile in the upper right corner > `API Keys` > `+ New API Key` and copy that API key token.
@@ -63,7 +63,7 @@ if (mario_have_api_key()) {
 ```
 If set up correctly, it should repeat back to you your API key.
 
-### Get your Google Slide ID
+### Google Slide ID that you'd like to translate into a video
 
 If you have a Google Slides set, you can obtain the Google Slides set ID from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
@@ -74,7 +74,7 @@ For testing purposes, we've included a set of [test slides](https://docs.google.
 ## Running Mario
 
 ```{r, eval = FALSE}
-# Google slide ID
+# Google Slides ID
 id <- "1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk"
 
 # Run mario!

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,25 +33,26 @@ remotes::install_github("jhudsl/mario")
 ## Example
 
 Before you can run `mario`, you will need two things:
-1) An API Key and
-2) Your Google slide ID that you'd like to translate into a video.
+
+1) An API Key
+2) Your Google slide ID that you'd like to translate into a video
 
 ### Get and set the API Key
 
 You will need access to the mario RSConnect through your institution. For example, JHU users will login at https://rsconnect.biostat.jhsph.edu/connect/. Once there, you'll need to obtain an API token.
 Click on your profile in the upper right corner > `API Keys` > `+ New API Key` and copy that API key token.
 
-In your local RStudio copy your API key in a command like this and run it:
-```
+In your local RStudio copy your API key in a command like this and run:
+
+```{r, eval = FALSE}
 Sys.setenv(CONNECT_API_KEY = "your-api-key")
 ```
-Now the API Key is stored in `~/.Renviron` as a hidden file.
+You should only need to do this once per your RStudio environment. Your API key is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the api key functions below use by default, e.g.:
 
-You should only need to do this once per your RStudio environment.
-For now, the Mario API Key is stored in `~/.Renviron` as a hidden file.
-It is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the api key functions below use by default, e.g.:
+```{r, eval = FALSE}
+mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))
+```
 
-`mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))`
 
 
 Now to test if your API key has been set up correctly, run this:
@@ -62,7 +63,7 @@ if (mario_have_api_key()) {
   mario_api_key()
 }
 ```
-If it is set up correctly, if should repeat back to you your API key.
+If set up correctly, it should repeat back to you your API key.
 
 ### Get your Google Slide ID
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ remotes::install_github("jhudsl/mario")
 
 ## Example
 
-Before you can run `mario`, you will need two things: 1) An API Key and
-2) Your Google slide ID that you’d like to translate into a video.
+Before you can run `mario`, you will need two things:
+
+1)  An API Key
+2)  Your Google slide ID that you’d like to translate into a video
 
 ### Get and set the API Key
 
@@ -36,35 +38,39 @@ For example, JHU users will login at
 to obtain an API token. Click on your profile in the upper right corner
 \> `API Keys` \> `+ New API Key` and copy that API key token.
 
-In your local RStudio copy your API key in a command like this and run
-it:
+In your local RStudio copy your API key in a command like this and run:
 
-    Sys.setenv(CONNECT_API_KEY = "your-api-key")
+``` r
+Sys.setenv(CONNECT_API_KEY = "your-api-key")
+```
 
-Now the API Key is stored in `~/.Renviron` as a hidden file.
+You should only need to do this once per your RStudio environment. Your
+API key is called `CONNECT_API_KEY`. You can call it something else, but
+this is the name that the api key functions below use by default, e.g.:
 
-You should only need to do this once per your RStudio environment. For
-now, the Mario API Key is stored in `~/.Renviron` as a hidden file. It
-is called `CONNECT_API_KEY`. You can call it something else, but this is
-the name that the api key functions below use by default, e.g.:
-
-`mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))`
+``` r
+mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))
+```
 
 Now to test if your API key has been set up correctly, run this:
 
-    if (mario_have_api_key()) {
-      mario_api_key()
-    }
+``` r
+library(mario)
 
-If it is set up correctly, if should repeat back to you your API key.
+if (mario_have_api_key()) {
+  mario_api_key()
+}
+```
+
+If set up correctly, it should repeat back to you your API key.
 
 ### Get your Google Slide ID
 
-If you have a google slide set, you can obtain the google slide set ID
+If you have a Google Slides set, you can obtain the Google Slides set ID
 from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
-Your [Google slides
+Your [Google Slides
 permissions](https://artofpresentations.com/give-permissions-on-google-slides/)
 must be set to `Anyone with the link` For testing purposes, we’ve
 included a set of [test
@@ -83,8 +89,7 @@ res <- mario::mario(id,
 
 # Write the video
 mario::mario_write_video(
-  res,
-  file = file.path())
+  res)
 ```
 
 Mario will print a file path to the newly rendered video in the console.

--- a/README.md
+++ b/README.md
@@ -99,3 +99,22 @@ If you’d like to see a list of all the voice options:
 voice_options <- mario_voices()
 head(voice_options)
 ```
+
+## Getting Mario subtitles for YouTube
+
+``` r
+# Extract the subtitles
+subtitles <- mario::mario_subtitles(res)
+# Write the subtitles to file
+readr::write_lines(subtitles, "out.txt")
+```
+
+On YouTube:
+
+- Navigate to <https://studio.youtube.com>
+- Go to “Subtitles” on the left hand menu
+- Click on the video to which you want to add subtitles
+- Click the “ADD” link under “Subtitles” in the table
+- Select Upload File and select “With timing”
+- Upload the “out.txt” file created above
+- Once checked, click “PUBLISH”

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 
 [![Travis build
-status](https://travis-ci.com/jhudsl/ariExtra.svg?branch=master)](https://travis-ci.com/jhudsl/ariExtra)
+status](https://travis-ci.com/jhudsl/mario.svg?branch=master)](https://travis-ci.com/jhudsl/mario)
 [![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/jhudsl/ariExtra?branch=master&svg=true)](https://ci.appveyor.com/project/jhudsl/ariExtra)
+Status](https://ci.appveyor.com/api/projects/status/github/jhudsl/mario?branch=master&svg=true)](https://ci.appveyor.com/project/jhudsl/mario)
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # mario Package:
 
-The goal of `mario` is to create automatically create videos from a Google slides.
-Whatever is written in the speaker notes section of the Google slides will be read in the video.
+The goal of `mario` is to create automatically create videos from a
+Google slides. Whatever is written in the speaker notes section of the
+Google slides will be read in the video.
 
-If you update the slides, all you need to do is re-run `mario` to update the video.
+If you update the slides, all you need to do is re-run `mario` to update
+the video.
 
 ## Installation
 
@@ -23,47 +25,55 @@ remotes::install_github("jhudsl/mario")
 
 ## Example
 
-Before you can run `mario`, you will need two things:
-1) An API Key and
-2) Your Google slide ID that you'd like to translate into a video.
+Before you can run `mario`, you will need two things: 1) An API Key and
+2) Your Google slide ID that you’d like to translate into a video.
 
 ### Get and set the API Key
 
-You will need access to the mario RSConnect and you'll need to obtain an API token.
-Click on your profile in the upper right corner > `API Keys` > `+ New API Key` and copy that API key token.
+You will need access to the mario RSConnect through your institution.
+For example, JHU users will login at
+<https://rsconnect.biostat.jhsph.edu/connect/>. Once there, you’ll need
+to obtain an API token. Click on your profile in the upper right corner
+\> `API Keys` \> `+ New API Key` and copy that API key token.
 
-In your local RStudio copy your API key in a command like this and run it:
-```
-Sys.setenv(CONNECT_API_KEY = "your-api-key")
-```
+In your local RStudio copy your API key in a command like this and run
+it:
+
+    Sys.setenv(CONNECT_API_KEY = "your-api-key")
+
 Now the API Key is stored in `~/.Renviron` as a hidden file.
 
-You should only need to do this once per your RStudio environment.
-For now, the Mario API Key is stored in `~/.Renviron` as a hidden file.
-It is called `CONNECT_API_KEY`. You can call it something else, but this is the name that the api key functions below use by default, e.g.:
+You should only need to do this once per your RStudio environment. For
+now, the Mario API Key is stored in `~/.Renviron` as a hidden file. It
+is called `CONNECT_API_KEY`. You can call it something else, but this is
+the name that the api key functions below use by default, e.g.:
 
 `mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))`
 
-
 Now to test if your API key has been set up correctly, run this:
-```
-if (mario_have_api_key()) {
-  mario_api_key()
-}
-```
+
+    if (mario_have_api_key()) {
+      mario_api_key()
+    }
+
 If it is set up correctly, if should repeat back to you your API key.
 
 ### Get your Google Slide ID
 
-If you have a google slide set, you can obtain the google slide set ID from the URL:
+If you have a google slide set, you can obtain the google slide set ID
+from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
-Your [Google slides permissions](https://artofpresentations.com/give-permissions-on-google-slides/) must be set to `Anyone with link can view`
-For testing purposes, we've included a set of [test slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p) you can use to practice.
+Your [Google slides
+permissions](https://artofpresentations.com/give-permissions-on-google-slides/)
+must be set to `Anyone with the link` For testing purposes, we’ve
+included a set of [test
+slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p)
+you can use to practice.
 
 ## Running Mario
 
-```{r}
+``` r
 # Google slide ID
 id <- "1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk"
 
@@ -73,33 +83,14 @@ res <- mario::mario(id,
 
 # Write the video
 mario::mario_write_video(
-  res
+  res,
   file = file.path())
 ```
 
-If you'd like to see a list of all the voice options:
+Mario will print a file path to the newly rendered video in the console.
+If you’d like to see a list of all the voice options:
 
-```{r}
+``` r
 voice_options <- mario_voices()
 head(voice_options)
 ```
-
-## Getting Mario subtitles for YouTube
-
-```{r}
-# Extract the subtitles
-subtitles <- mario::mario_subtitles(res)
-
-# Write the subtitles to file
-readr::write_lines(subtitles, "out.txt")
-```
-
-On YouTube:
-
-- Navigate to [https://studio.youtube.com](https://studio.youtube.com)
-- Go to "Subtitles" on the lefthand menu
-- Click on the video to which you want to add subtitles
-- Click the "ADD" link under "Subtitles" in the table
-- Select Upload File and select "With timing"
-- Upload the "out.txt" file created above
-- Once checked, click "PUBLISH"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Status](https://ci.appveyor.com/api/projects/status/github/jhudsl/mario?branch=m
 
 # mario Package:
 
-The goal of `mario` is to create automatically create videos from a
+The goal of `mario` is to automatically create videos from a set of
 Google slides. Whatever is written in the speaker notes section of the
 Google slides will be read in the video.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ In your local RStudio, copy your API key in a command like this and run:
 Sys.setenv(CONNECT_API_KEY = "your-api-key")
 ```
 
-You should only need to do this once per your RStudio environment. Your
-API key is called `CONNECT_API_KEY`. You can call it something else, but
-this is the name that the API key functions below use by default, e.g.:
+It is stored in the environment for the current R session. You should
+only need to do this once per your RStudio environment. Your API key is
+called `CONNECT_API_KEY`. You can call it something else, but this is
+the name that the API key functions below use by default, e.g.:
 
 ``` r
 mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Status](https://ci.appveyor.com/api/projects/status/github/jhudsl/mario?branch=m
 # mario Package:
 
 The goal of `mario` is to automatically create videos from a set of
-Google slides. Whatever is written in the speaker notes section of the
-Google slides will be read in the video.
+Google Slides. Whatever is written in the speaker notes section of the
+Google Slides will be read in the video.
 
 If you update the slides, all you need to do is re-run `mario` to update
 the video.
@@ -27,10 +27,10 @@ remotes::install_github("jhudsl/mario")
 
 Before you can run `mario`, you will need two things:
 
-1)  An API Key
-2)  Your Google slide ID that you’d like to translate into a video
+1)  [API Key](#api-key)
+2)  [Google Slides ID](#google-slides-id)
 
-### Get and set the API Key
+### API Key
 
 You will need access to the mario RSConnect through your institution.
 For example, JHU users will login at
@@ -38,7 +38,7 @@ For example, JHU users will login at
 to obtain an API token. Click on your profile in the upper right corner
 \> `API Keys` \> `+ New API Key` and copy that API key token.
 
-In your local RStudio copy your API key in a command like this and run:
+In your local RStudio, copy your API key in a command like this and run:
 
 ``` r
 Sys.setenv(CONNECT_API_KEY = "your-api-key")
@@ -46,7 +46,7 @@ Sys.setenv(CONNECT_API_KEY = "your-api-key")
 
 You should only need to do this once per your RStudio environment. Your
 API key is called `CONNECT_API_KEY`. You can call it something else, but
-this is the name that the api key functions below use by default, e.g.:
+this is the name that the API key functions below use by default, e.g.:
 
 ``` r
 mario_auth(api_key = Sys.getenv("CONNECT_API_KEY"))
@@ -64,23 +64,23 @@ if (mario_have_api_key()) {
 
 If set up correctly, it should repeat back to you your API key.
 
-### Get your Google Slide ID
+### Google Slides ID
 
 If you have a Google Slides set, you can obtain the Google Slides set ID
 from the URL:
 `https://docs.google.com/presentation/d/**presentationId**/edit`
 
 Your [Google Slides
-permissions](https://artofpresentations.com/give-permissions-on-google-slides/)
-must be set to `Anyone with the link` For testing purposes, we’ve
-included a set of [test
+permissions](https://www.youtube.com/watch?v=zHSfwaZIVbM) must be set to
+`Anyone with the link`. For testing purposes, we’ve included a set of
+[test
 slides](https://docs.google.com/presentation/d/1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk/edit#slide=id.p)
 you can use to practice.
 
 ## Running Mario
 
 ``` r
-# Google slide ID
+# Google Slides ID
 id <- "1sFsRXfK7LKxFm-ydib5dxyQU9fYujb95katPRu0WVZk"
 
 # Run mario!


### PR DESCRIPTION
1. I noticed that `Sys.setenv(CONNECT_API_KEY = "your-api-key")` does not store the API key in `~/.Renviron`, but only stores the API Key as an environment variable for the current R session, so I made some changes to the wording.

2. Made some cosmetic changes, like adding code highlighting and changing the link to "Google Slides permissions" to an Youtube video.